### PR TITLE
ENH+TST Expand subfeatures when counting with a GFF file

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,7 @@ Version 0.7.1+
 	output)
 	* Add non-ATCG fraction field to FastQ statistics
 	* Add reference argument to count()
+	* GFF based counting now expands multi-value sub-features
 
 Version 0.7.1 2018-03-17 by luispedro
 	* Fix memory leak in count()

--- a/NGLess/Data/GFF.hs
+++ b/NGLess/Data/GFF.hs
@@ -49,7 +49,8 @@ instance NFData GffLine where
 gffId GffLine { gffAttrs = attrs } = fromMaybe "unknown" (lookup "ID" attrs <|> lookup "gene_id" attrs)
 
 _parseGffAttributes :: B.ByteString -> [(B.ByteString, B.ByteString)]
-_parseGffAttributes = map (second (B8.filter (/='\"') . B.tail))
+_parseGffAttributes = foldMap (\(a, b) -> zip (repeat a) (B8.split ',' b))
+                        . map (second (B8.filter (/='\"') . B.tail))
                         . map (\x -> B8.break (== (checkAttrTag x)) x)
                         . map _trimString
                         . B8.split ';'

--- a/tests/count-subfeatures/.gitignore
+++ b/tests/count-subfeatures/.gitignore
@@ -1,0 +1,1 @@
+../count-mode/.gitignore

--- a/tests/count-subfeatures/count-subfeatures.ngl
+++ b/tests/count-subfeatures/count-subfeatures.ngl
@@ -1,0 +1,14 @@
+ngless '0.7'
+
+input = fastq('reads.fq.gz')
+mapped = map(input, fafile='ref.fna.gz')
+
+uniqueOnly  = count(mapped, gff_file='features.gtf', features=['gene'], subfeatures=['gene_name'], multiple={unique_only})
+allOne      = count(mapped, gff_file='features.gtf', features=['gene'], subfeatures=['gene_name'], multiple={all1})
+oneOverN    = count(mapped, gff_file='features.gtf', features=['gene'], subfeatures=['gene_name'], multiple={1overN})
+distOne     = count(mapped, gff_file='features.gtf', features=['gene'], subfeatures=['gene_name'], multiple={dist1})
+
+write(uniqueOnly, ofile='output.unique_only.txt')
+write(allOne,     ofile='output.all1.txt')
+write(oneOverN,   ofile='output.1overN.txt')
+write(distOne,    ofile='output.dist1.txt')

--- a/tests/count-subfeatures/features.gtf
+++ b/tests/count-subfeatures/features.gtf
@@ -1,0 +1,11 @@
+##gff-version 3
+# 2 reads + 2 overlap with next
+reference	protein_coding	gene	40	100	.	+	.	gene_id=geneY;gene_name=feature_A,feature_B,feature_D
+# 0 reads + 2 overlap with previous
+reference	protein_coding	gene	110	130	.	+	.	gene_id=geneW;gene_name=feature_B
+# 1 read
+reference	protein_coding	gene	140	200	.	+	.	gene_id=geneX;gene_name=feature_A
+# 1 partial read + 1 overlap with next (where features also overlap)
+reference	protein_coding	gene	230	310	.	+	.	gene_id=geneY;gene_name=feature_C
+# 1 partial read + 1 overlap with previous (where features also overlap)
+reference	protein_coding	gene	280	360	.	+	.	gene_id=geneZ;gene_name=feature_D

--- a/tests/count-subfeatures/readme.txt
+++ b/tests/count-subfeatures/readme.txt
@@ -1,0 +1,48 @@
+Reads were artificially produced from the reference in order to match the following illustration:
+
+    Name      Representation                            Coords
+    reference ========================================   1:400
+        geneV     ******                                40:100
+        geneW            **                            110:130
+        geneX               *******                    140:200
+        geneY                         ********         230:310
+        geneZ                              ********    280:360
+
+                                            # of regions / feature size
+    feature_A     ******    *******                    2 / 120
+    feature_B     ****** **                            2 /  80
+    feature_C                         ********         1 /  80
+    feature_D     ******                   ********    2 / 140
+
+        read0   +++++                                   20:70
+        read1      +++++                                50:100
+        read2        +++++                              70:120
+        read3          +++++                            90:140
+        read4               +++++                      140:190
+        read5                      +++++               210:260
+        read6                         +++++            240:290
+        read7                             +++++        280:330
+        read8                                   +++++  340:390
+
+
+Expected feature counts per-read are:
+
+           uniqueOnly  allOne  oneOverN  distOne
+    read0           -     ABD       ABD       AD
+    read1           -     ABD       ABD       AD
+    read2           -     ABD       ABD       AD
+    read3           -     ABD       ABD       AD
+    read4           A       A         A        A
+    read5           C       C         C        C
+    read6           -      CD        CD       CD
+    read7           -      CD        CD       CD
+    read8           D       D         D        D
+
+results the following feature counts:
+
+           uniqueOnly  allOne  oneOverN  distOne
+       -1           0       0         0        0
+feature_A           1       5      2.33     3.15
+feature_B           0       4      1.33        0
+feature_C           1       3         2     2.27
+feature_D           1       7      3.33     3.57

--- a/tests/count-subfeatures/reads.fq.gz
+++ b/tests/count-subfeatures/reads.fq.gz
@@ -1,0 +1,1 @@
+../count-mode/reads.fq.gz

--- a/tests/count-subfeatures/ref.fna.gz
+++ b/tests/count-subfeatures/ref.fna.gz
@@ -1,0 +1,1 @@
+../count-mode/ref.fna.gz


### PR DESCRIPTION
Using a GFF containing `"gene_name=nameA,nameB"` would result in:

    nameA,nameB    1

Now the same results in:

    nameA    1
    nameB    1

This follows after https://git.io/vpagq and the case of:

    Parent=AF2312,AB2812,abc-3